### PR TITLE
Fixed typo: "Paggett" should be "Pagett."

### DIFF
--- a/src/epub/text/chapter-20.xhtml
+++ b/src/epub/text/chapter-20.xhtml
@@ -120,7 +120,7 @@
 			<p>“I’ll come and see you off. It’s just eight o’clock, your train goes in a quarter of an hour.”</p>
 			<p>He gave efficient directions to porters. I stood helpless, not daring to look at Suzanne. The man suspected. He was determined to make sure that I did go by the train. And what could I do? Nothing. I saw myself, in a quarter of an hour’s time, steaming out of the station with Pagett planted on the platform waving me adieu. He had turned the tables on me adroitly. His manner towards me had changed, moreover. It was full of an uneasy geniality which sat ill upon him, and which nauseated me. The man was an oily hypocrite. First he tried to murder me, and now he paid me compliments! Did he imagine for one minute that I hadn’t recognized him that night on the boat? No, it was a pose, a pose which he forced me to acquiesce in, his tongue in his cheek all the while.</p>
 			<p>Helpless as a sheep, I moved along under his expert directions. My luggage was piled in my sleeping compartment⁠—I had a two-berth one to myself. It was twelve minutes past eight. In three minutes the train would start.</p>
-			<p>But Paggett had reckoned without Suzanne.</p>
+			<p>But Pagett had reckoned without Suzanne.</p>
 			<p>“It will be a terribly hot journey, Anne,” she said suddenly. “Especially going through the Karoo tomorrow. You’ve got some eau de cologne or lavender water with you, haven’t you?”</p>
 			<p>My cue was plain.</p>
 			<p>“Oh, dear,” I cried. “I left my eau de cologne on the dressing table at the hotel.”</p>


### PR DESCRIPTION
I think "Paggett" reads better, but everywhere else in the book it's spelled "Pagett."
